### PR TITLE
Removing rack-cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,6 @@ gem 'fog-aws'
 
 # caching
 gem 'dalli' # memcache
-gem 'rack-cache' # http caching
 gem 'kgio' # faster kgio IO system
 
 # rollbar

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,8 +264,6 @@ GEM
     rabl (0.12.0)
       activesupport (>= 2.3.14)
     rack (1.6.4)
-    rack-cache (1.6.1)
-      rack (>= 0.4)
     rack-protection (1.5.3)
       rack
     rack-test (0.6.3)
@@ -522,7 +520,6 @@ DEPENDENCIES
   pry-stack_explorer
   puma
   quiet_assets
-  rack-cache
   rack-timeout
   rails (= 4.2.6)
   rails_12factor

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -14,12 +14,6 @@ Rails.application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
-  # Enable Rack::Cache to put a simple HTTP cache in front of your application
-  # Add `rack-cache` to your Gemfile before enabling this.
-  # For large-scale production use, consider using a caching reverse proxy like
-  # NGINX, varnish or squid.
-  config.action_dispatch.rack_cache = true
-
   # Action mailer con host production
   if ENV['APP_DOMAIN']
     config.action_mailer.default_url_options = { host: 'https://' + ENV['APP_DOMAIN'] }
@@ -71,14 +65,6 @@ Rails.application.configure do
     }
 
     config.cache_store = :mem_cache_store, ENV['MEMCACHEDCLOUD_SERVERS'].split(','), memcached_config
-
-    client = Dalli::Client.new(ENV['MEMCACHEDCLOUD_SERVERS'].split(','), memcached_config)
-
-    config.action_dispatch.rack_cache = {
-      metastore: client,
-      entitystore: client,
-      verbose: false
-    }
   end
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.


### PR DESCRIPTION
`rack-cache` for larger deployments can cause troubles. It’s better to use a dedicated cache layer like `fastly`