### PR TITLE
Normalize API endpoints

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -193,7 +193,7 @@ StringLiterals:
 VariableInterpolation:
   Enabled: false
 
-TrailingComma:
+TrailingCommaInLiteral:
   Enabled: false
 
 TrivialAccessors:

--- a/app/controllers/concerns/spree/api_frontend_fix_concern.rb
+++ b/app/controllers/concerns/spree/api_frontend_fix_concern.rb
@@ -1,0 +1,13 @@
+module Spree
+  module ApiFrontendFixConcern
+    extend ActiveSupport::Concern
+    included do
+      before_action :prepare_user_and_roles_for_api_views
+    end
+
+    def prepare_user_and_roles_for_api_views
+      @current_api_user = spree_current_user
+      @current_user_roles = @current_api_user ? @current_api_user.spree_roles.pluck(:name) : []
+    end
+  end
+end

--- a/app/controllers/spree/orders_controller_decorator.rb
+++ b/app/controllers/spree/orders_controller_decorator.rb
@@ -1,4 +1,7 @@
 Spree::OrdersController.class_eval do
+  helper Spree::Api::ApiHelpers
+  include Spree::ApiFrontendFixConcern
+
   # Adds a new item to the order (creating a new order if none already exists)
   def populate
     order    = current_order(create_order_if_necessary: true)
@@ -27,7 +30,10 @@ Spree::OrdersController.class_eval do
       end
     else
       respond_with(order) do |format|
-        format.json { render json: order }
+        format.json do
+          @order = order
+          render 'spree/api/v1/orders/show', layout: false
+        end
         format.html { redirect_to cart_path }
       end
     end

--- a/app/controllers/spree/store_controller_decorator.rb
+++ b/app/controllers/spree/store_controller_decorator.rb
@@ -1,6 +1,9 @@
 Spree::StoreController.class_eval do
   layout 'application_classic'
 
+  helper Spree::Api::ApiHelpers
+  include Spree::ApiFrontendFixConcern
+
   skip_before_action :set_current_order, only: [:cart_link, :account_link,
                                                 :authenticity_token]
 
@@ -9,12 +12,15 @@ Spree::StoreController.class_eval do
     fresh_when spree_current_user
   end
 
+  # for consistency reasons we want to use the same order json format
+  # everywhere in the application
   def cart_link
-    render json: simple_current_order
-    fresh_when simple_current_order
+    @order = simple_current_order
+    render 'spree/api/v1/orders/show', layout: false
+    fresh_when @order
   end
 
   def authenticity_token
-    render json: { authenticityToken: form_authenticity_token }
+    render json: { authenticity_token: form_authenticity_token }
   end
 end

--- a/app/helpers/api_helper.rb
+++ b/app/helpers/api_helper.rb
@@ -19,6 +19,6 @@ module ApiHelper
       prev_page: object.prev_page,
       total_pages: object.total_pages,
       total_count: object.total_count
-    }.map { |k, v| [k.to_s.camelize(:lower).chomp('?').to_sym, v] }.to_h
+    }
   end
 end

--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -1,26 +1,2 @@
 class ApplicationSerializer < ActiveModel::Serializer
-  def attributes(options = {})
-    super(options).map { |k, v| [k.to_s.camelize(:lower).chomp('?').to_sym, v] }.to_h
-  end
-
-  def self.has_many(*args)
-    options = args.extract_options!
-    options.reverse_merge!(key: args.first.to_s.camelize(:lower).to_sym)
-    args << options
-    super(*args)
-  end
-
-  def self.has_one(*args)
-    options = args.extract_options!
-    options.reverse_merge!(key: args.first.to_s.camelize(:lower).to_sym)
-    args << options
-    super(*args)
-  end
-
-  def self.belongs_to(*args)
-    options = args.extract_options!
-    options.reverse_merge!(key: args.first.to_s.camelize(:lower).to_sym)
-    args << options
-    super(*args)
-  end
 end

--- a/app/serializers/spree/order_serializer.rb
+++ b/app/serializers/spree/order_serializer.rb
@@ -1,8 +1,0 @@
-module Spree
-  class OrderSerializer < ApplicationSerializer
-    attributes :id, :total, :currency, :guest_token, :user_id
-
-    has_many :line_items
-    has_many :adjustments
-  end
-end

--- a/client/js/actions/login.js
+++ b/client/js/actions/login.js
@@ -12,7 +12,7 @@ export function login(email, password) {
   return (dispatch, getState) => {
     dispatch(loginRequest())
 
-    const authenticityToken = getAuthenticityToken(getState()).authenticityToken
+    const authenticityToken = getAuthenticityToken(getState()).authenticity_token
 
     const formData = new FormData()
     formData.append('spree_user[email]', email)

--- a/client/js/components/Pagination.js
+++ b/client/js/components/Pagination.js
@@ -15,7 +15,7 @@ export default (props) => {
     dispatch(routerActions.push(newPath))
   }
 
-  if (!pagination || !pagination.totalPages || parseInt(pagination.totalPages) === 1) {
+  if (!pagination || !pagination.total_pages || parseInt(pagination.total_pages, 10) === 1) {
     return <div />
   }
 
@@ -27,9 +27,9 @@ export default (props) => {
         first={true}
         last={true}
         ellipsis={true}
-        items={parseInt(pagination.totalPages)}
+        items={parseInt(pagination.total_pages, 10)}
         maxButtons={5}
-        activePage={parseInt(location.query.page) || 1}
+        activePage={parseInt(location.query.page, 10) || 1}
         onSelect={handleSelect}
       />
     </div>

--- a/client/js/pages/Product/CartForm.js
+++ b/client/js/pages/Product/CartForm.js
@@ -33,7 +33,7 @@ class CartForm extends Component {
             defaultChecked={this.props.selectedVariant.id === variant.id}
           />
           &nbsp;
-          {variant.optionsText}
+          {variant.options_text}
         </label>
       </div>
     )

--- a/client/js/pages/Product/Properties.js
+++ b/client/js/pages/Product/Properties.js
@@ -3,7 +3,7 @@ import React from 'react'
 export default (props) => {
   const { product } = props
 
-  if (!product.productProperties.length) {
+  if (!product.product_properties.length) {
     return <div />
   }
 
@@ -12,7 +12,7 @@ export default (props) => {
       <h3 className="product-section-title">{I18n.t('spree.properties')}</h3>
       <table id="product-properties" className="table table-striped" data-hook="">
         <tbody>
-          {product.productProperties.map((property, index) => {
+          {product.product_properties.map((property, index) => {
             return (
               <tr key={property.id} className={index % 2 && 'even' || 'odd'}>
                 <td><strong>{property.name}</strong></td>

--- a/client/js/reducers/authenticityToken.js
+++ b/client/js/reducers/authenticityToken.js
@@ -1,4 +1,6 @@
-import { FETCH_AUTHENTICITY_TOKEN_REQUEST, FETCH_AUTHENTICITY_TOKEN_SUCCESS, FETCH_AUTHENTICITY_TOKEN_FAILURE } from 'constants'
+import {
+  FETCH_AUTHENTICITY_TOKEN_REQUEST, FETCH_AUTHENTICITY_TOKEN_SUCCESS, FETCH_AUTHENTICITY_TOKEN_FAILURE
+} from 'constants'
 
 export function getAuthenticityToken(state) {
   return state.authenticityToken

--- a/config/application.rb
+++ b/config/application.rb
@@ -59,8 +59,6 @@ module SparkStarterKit
       files: ['application.server.js'], # files to load for prerendering
       replay_console: true, # if true, console.* will be replayed client-side
     }
-    # use camel case convention for react components props
-    config.react.camelize_props = true
 
     if Rails.env.production?
       # CloudFlare middleware for proper visitors IP addresses


### PR DESCRIPTION
* for orders always using RABL template to be consistent with Spree API
* dropping CamelCase to be consistent with Spree API
