### PR TITLE
Utilising Heroku Release Phase to run migrations

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,2 @@
 https://github.com/heroku/heroku-buildpack-nodejs.git
 https://github.com/heroku/heroku-buildpack-ruby.git
-https://github.com/gunpowderlabs/buildpack-ruby-rake-deploy-tasks

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
+release: bundle exec rake db:migrate
 web: bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq -C config/sidekiq.yml

--- a/README.md
+++ b/README.md
@@ -38,9 +38,6 @@ heroku buildpacks:add heroku/nodejs
 ```
 heroku buildpacks:add heroku/ruby
 ```
-```
-heroku buildpacks:add https://github.com/gunpowderlabs/buildpack-ruby-rake-deploy-tasks
-```
 
 ## License
 


### PR DESCRIPTION
Thanks to [Release Phase](https://devcenter.heroku.com/articles/release-phase) we don’t need additional buildpack to run migrations on deploys.