### PR TITLE
Fix for alert format returned by spree_auth_devise

### DIFF
--- a/app/helpers/spree/frontend_helper_decorator.rb
+++ b/app/helpers/spree/frontend_helper_decorator.rb
@@ -2,6 +2,7 @@ Spree::FrontendHelper.module_eval do
   def class_for(flash_type)
     {
       success: 'success',
+      registration_error: 'danger',
       error:   'danger',
       alert:   'danger',
       warning: 'warning',


### PR DESCRIPTION
This was fixed in `master` (https://github.com/spree/spree_auth_devise/pull/361) but as we're using `3.1` we need this workaround for now.