### PR TITLE
fixes multiple loginform default error (redux)

### DIFF
--- a/client/js/components/LoginForm.js
+++ b/client/js/components/LoginForm.js
@@ -19,7 +19,7 @@ const submit = (values, dispatch) => {
   })
 }
 
-export default class LoginForm extends Component {
+export class LoginForm extends Component {
   static propTypes = {
     fields: PropTypes.object.isRequired,
     handleSubmit: PropTypes.func.isRequired,


### PR DESCRIPTION
this is based on the issue raised here:
https://github.com/spark-solutions/spark-starter-kit/issues/57

Module build failed: SyntaxError: /../client/js/components/LoginForm.js: Only one default export allowed per module.