### PR TITLE
Update react-rails to 1.9.0 and polyfill setTimeout for prerendering

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,7 +303,7 @@ GEM
       activesupport (>= 3.0)
       i18n
       polyamorous (~> 1.1)
-    react-rails (1.8.0)
+    react-rails (1.9.0)
       babel-transpiler (>= 0.7.0)
       coffee-script-source (~> 1.8)
       connection_pool

--- a/config/application.rb
+++ b/config/application.rb
@@ -55,7 +55,13 @@ module SparkStarterKit
     config.react.server_renderer_pool_size  ||= 1  # ExecJS doesn't allow more than one on MRI
     config.react.server_renderer_timeout    ||= 20 # seconds
     config.react.server_renderer = React::ServerRendering::SprocketsRenderer
+
+    js_polyfill = File.read(File.join("lib/server_side_rendering/set_timeout_polyfill.js"))
+
     config.react.server_renderer_options = {
+      # temporarily polyfill setTimeout() for SSR
+      # remove this if covered by react-rails
+      code: js_polyfill,
       files: ['application.server.js'], # files to load for prerendering
       replay_console: true, # if true, console.* will be replayed client-side
     }

--- a/lib/server_side_rendering/set_timeout_polyfill.js
+++ b/lib/server_side_rendering/set_timeout_polyfill.js
@@ -1,0 +1,18 @@
+function getStackTrace() {
+  var stack;
+  try {
+    throw new Error('');
+  }
+  catch (error) {
+    stack = error.stack || '';
+  }
+  stack = stack.split('\\n').map(function (line) {
+    return line.trim();
+  });
+  return stack.splice(stack[0] == 'Error' ? 2 : 1);
+}
+
+function setTimeout() {
+  console.error('setTimeout is not defined for execJS. See https://github.com/sstephenson/execjs#faq. Note babel-polyfill may call this.');
+  console.error(getStackTrace().join('\\n'));
+}


### PR DESCRIPTION
We have to update react-rails to 1.9.0 to use `code` options and pass polyfill for `setTimeout`
Fix #68