### PR TITLE
Fix source maps

### DIFF
--- a/client/.bootstraprc
+++ b/client/.bootstraprc
@@ -8,8 +8,8 @@ bootstrapVersion: 3
 # Webpack loaders, order matters
 styleLoaders:
   - style
-  - css
-  - sass
+  - css?sourceMap
+  - sass?sourceMap
 
 # Extract styles to stand-alone css file
 # Different settings for different environments can be used,

--- a/client/webpack.client.rails.hot.config.js
+++ b/client/webpack.client.rails.hot.config.js
@@ -54,7 +54,7 @@ config.module.loaders.push(
     test: /\.css$/,
     loaders: [
       'style',
-      'css?modules&importLoaders=1&localIdentName=[name]__[local]__[hash:base64:5]',
+      'css?modules&sourceMap&importLoaders=1&localIdentName=[name]__[local]__[hash:base64:5]',
       'postcss',
     ],
   },
@@ -62,9 +62,9 @@ config.module.loaders.push(
     test: /\.scss$/,
     loaders: [
       'style',
-      'css?modules&importLoaders=3&localIdentName=[name]__[local]__[hash:base64:5]',
+      'css?modules&sourceMap&importLoaders=3&localIdentName=[name]__[local]__[hash:base64:5]',
       'postcss',
-      'sass',
+      'sass?sourceMap',
       'sass-resources',
     ],
   }

--- a/client/webpack.server.rails.build.config.js
+++ b/client/webpack.server.rails.build.config.js
@@ -48,14 +48,14 @@ module.exports = {
       {
         test: /\.css$/,
         loaders: [
-          'css/locals?modules&importLoaders=0&localIdentName=[name]__[local]__[hash:base64:5]'
+          'css/locals?modules&sourceMap&importLoaders=0&localIdentName=[name]__[local]__[hash:base64:5]'
         ]
       },
       {
         test: /\.scss$/,
         loaders: [
-          'css/locals?modules&importLoaders=2&localIdentName=[name]__[local]__[hash:base64:5]',
-          'sass',
+          'css/locals?modules&sourceMap&importLoaders=2&localIdentName=[name]__[local]__[hash:base64:5]',
+          'sass?sourceMap',
           'sass-resources'
         ]
       },


### PR DESCRIPTION
Enable source maps everywhere except production build. Now developers can see where those styles are coming from.

![2016-11-06 12 58 18](https://cloud.githubusercontent.com/assets/29921/20037523/0fb0ee9e-a421-11e6-9389-862514f3f4ac.png)
