### PR TITLE
Fix `webpack:assets` potential failures

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -19,7 +19,7 @@ namespace :assets do
 
     # Critical to manually copy non js/css assets to public/assets as we don't want to fingerprint them
     sh 'cp -rf app/assets/webpack/*.woff* app/assets/webpack/*.svg app/assets/webpack/*.ttf '\
-       'app/assets/webpack/*.eot* app/assets/webpack/*.png app/assets/webpack/*.jpg public/assets'
+       'app/assets/webpack/*.eot* app/assets/webpack/*.png app/assets/webpack/*.jpg public/assets > /dev/null 2>&1'
 
     # TODO: We should be gzipping these
   end

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -19,7 +19,7 @@ namespace :assets do
 
     # Critical to manually copy non js/css assets to public/assets as we don't want to fingerprint them
     sh 'cp -rf app/assets/webpack/*.woff* app/assets/webpack/*.svg app/assets/webpack/*.ttf '\
-       'app/assets/webpack/*.eot* app/assets/webpack/*.png app/assets/webpack/*.jpg public/assets > /dev/null 2>&1'
+       'app/assets/webpack/*.eot* app/assets/webpack/*.png app/assets/webpack/*.jpg public/assets > /dev/null 2>&1 || return 0'
 
     # TODO: We should be gzipping these
   end


### PR DESCRIPTION
This prevents the infamous `cp`command from failing (stdout and stderr) in case some file extensions are not in the `webpack` folder.