### PR TITLE
remove jscs from devdeps

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -99,7 +99,6 @@
     "eslint-plugin-react": "^4.0.0",
     "expect": "^1.14.0",
     "express": "^4.13.4",
-    "jscs": "^2.10.1",
     "jsdom": "^8.0.2",
     "mocha": "^2.4.5",
     "react-addons-test-utils": "^0.14.7",


### PR DESCRIPTION
JSCS has [merged](https://medium.com/@markelog/jscs-end-of-the-line-bc9bf0b3fdb2) with ESLint