### PR TITLE
Revert "Deprecation warnings"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ end
 
 # file uploades & assets
 gem 'paperclip' # Image Rescaling for aws
-gem 'aws-sdk'
+gem 'aws-sdk', '< 2.0'
 gem 'fog-aws'
 
 # caching

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,14 +67,11 @@ GEM
     awesome_nested_set (3.1.2)
       activerecord (>= 4.0.0, < 5.1)
     awesome_print (1.7.0)
-    aws-sdk (2.9.7)
-      aws-sdk-resources (= 2.9.7)
-    aws-sdk-core (2.9.7)
-      aws-sigv4 (~> 1.0)
-      jmespath (~> 1.0)
-    aws-sdk-resources (2.9.7)
-      aws-sdk-core (= 2.9.7)
-    aws-sigv4 (1.0.0)
+    aws-sdk (1.66.0)
+      aws-sdk-v1 (= 1.66.0)
+    aws-sdk-v1 (1.66.0)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
@@ -191,7 +188,6 @@ GEM
     i18n-js (3.0.0.rc15)
       i18n (~> 0.6, >= 0.6.6)
     ipaddress (0.8.3)
-    jmespath (1.3.1)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -201,7 +197,7 @@ GEM
     js-routes (1.3.2)
       railties (>= 3.2)
       sprockets-rails
-    json (2.0.4)
+    json (1.8.6)
     jsonapi (0.1.1.beta6)
       jsonapi-parser (= 0.1.1.beta3)
       jsonapi-renderer (= 0.1.1.beta1)
@@ -489,7 +485,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers (~> 0.10.2)
   awesome_print
-  aws-sdk
+  aws-sdk (< 2.0)
   better_errors
   binding_of_caller
   bullet


### PR DESCRIPTION
Reverts spark-solutions/spark-starter-kit#131

@damianlegawiec unfortunately, `aws-sdk` >= 2 doesn't work with `paperclip` 4.3.7. We can't update `paperclip` because it's locked to `~> 4.3.0`