### PR TITLE
Remove deprecated babel package in favor of babel-cli

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "autoprefixer": "^6.3.3",
-    "babel": "6.23.0",
     "babel-cli": "^6.24.1",
     "babel-core": "^6.24.1",
     "babel-loader": "^6.4.1",


### PR DESCRIPTION
Using `babel` package is deprecated and using `babel-cli` is sufficient. Since node 8.x and npm 5.x starting server returns error and fails to start.
```
22:26:05 rails-assets.1        | You have mistakenly installed the `babel` package, which is a no-op in Babel 6.
22:26:05 rails-assets.1        | Babel's CLI commands have been moved from the `babel` package to the `babel-cli` package
``` 

Removing deprecated package fixes the issue