### PR TITLE
CDN and CDN_UPLOADS variables shouldn't be set for Heroku Review Apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,12 +12,6 @@
     "AWS_SECRET_ACCESS_KEY": {
       "required": true
     },
-    "CDN": {
-      "required": true
-    },
-    "CDN_UPLOADS": {
-      "required": true
-    },
     "DEPLOY_TASKS": {
       "required": true
     },


### PR DESCRIPTION
We want to use assets from this isolated instance, not from staging or production