### PR TITLE
Storage cache control + CDN

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -87,7 +87,7 @@ Rails.application.configure do
   end
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  if (host = heroku_app_url || ENV['CDN']).present?
+  if (host = ENV['CDN'] || heroku_app_url).present?
     config.action_controller.asset_host = config.action_mailer.asset_host = "https://#{host}"
   end
 

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -13,6 +13,8 @@ amazon:
   secret_access_key: <%= ENV['BUCKETEER_AWS_SECRET_ACCESS_KEY'] %>
   region: <%= ENV['BUCKETEER_AWS_REGION'] %>
   bucket: <%= ENV['BUCKETEER_BUCKET_NAME'] %>
+  upload:
+    cache_control: 'public, max-age=31536000'
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
## Description

To set cache-control header on S3 we can use ActiveStorage interface
https://github.com/rails/rails/blob/6-0-stable/activestorage/lib/active_storage/service/s3_service.rb#L12
It accepts upload options (from AWS SDK) that we can pass in storage.yml

## Checklist

Before you move on, make sure that:

- [x] No unintended changes are included
- [x] Spelling is correct
- There are tests covering new/changed functionality
- [x] Commits have meaningful names and changes. _CR remarks_-like commits are squashed.
- [x] Proper labels assigned. Use `WIP` label to indicate that state
